### PR TITLE
Add device properties improve docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -41,7 +41,6 @@ exclude =
     # example testing folder before going live
     thinking
     # custom scripts, not being part of the distribution
-    libs_external
     sdist_upip.py
     setup.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,11 @@ jobs:
       - name: Test built package
         run: |
           twine check dist/*
+      - name: Validate mip package file
+        run: |
+          upy-package \
+            --setup_file setup.py \
+            --package_changelog_file changelog.md \
+            --package_file package.json \
+            --validate \
+            --ignore-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
     branches-ignore:
       - 'main'
       - 'develop'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ MicroPython library to interact with Winbond W25Q Flash chips
 <!-- MarkdownTOC -->
 
 - [Installation](#installation)
-	- [Install required tools](#install-required-tools)
+    - [Install required tools](#install-required-tools)
 - [Stetup](#stetup)
-	- [Install package with upip](#install-package-with-upip)
-		- [General](#general)
-		- [Specific version](#specific-version)
-		- [Test version](#test-version)
-	- [Manually](#manually)
-		- [Upload files to board](#upload-files-to-board)
+    - [Install package](#install-package)
+        - [General](#general)
+        - [Specific version](#specific-version)
+        - [Test version](#test-version)
+    - [Manually](#manually)
+        - [Upload files to board](#upload-files-to-board)
 - [Usage](#usage)
 - [Credits](#credits)
 
@@ -62,13 +62,14 @@ rshell --help
 
 ## Stetup
 
-### Install package with upip
+### Install package
 
-Connect your MicroPython board to a network
+Connect the MicroPython device to a network (if possible)
 
 ```python
 import network
 station = network.WLAN(network.STA_IF)
+station.active(True)
 station.connect('SSID', 'PASSWORD')
 station.isconnected()
 ```
@@ -101,7 +102,8 @@ mip.install("github:brainelectronics/micropython-winbond", version="feature/add-
 mip.install("github:brainelectronics/micropython-winbond", version="0.4.0")
 ```
 
-For MicroPython versions below 1.19.1 use the `upip` package instead of `mip`
+For MicroPython versions below 1.19.1 use the `upip` package instead of `mip`.
+With `upip` always the latest available version will be installed.
 
 ```python
 import upip
@@ -120,7 +122,8 @@ import mip
 mip.install("github:brainelectronics/micropython-winbond", version="0.4.0-rc2.dev4")
 ```
 
-For MicroPython versions below 1.19.1 use the `upip` package instead of `mip`
+For MicroPython versions below 1.19.1 use the `upip` package instead of `mip`.
+With `upip` always the latest available version will be installed.
 
 ```python
 import upip
@@ -153,7 +156,7 @@ folders to the device
 mkdir /pyboard/lib
 mkdir /pyboard/lib/winbond
 
-cp winbond.py /pyboard/lib/winbond
+cp winbond/* /pyboard/lib/winbond
 cp main.py /pyboard/lib/winbond
 cp boot.py /pyboard/lib/winbond
 ```
@@ -166,6 +169,7 @@ import os
 from winbond import W25QFlash
 
 # the used SPI and CS pin is setup specific, change accordingly
+# check the boot.py file of this repo for further boards
 flash = W25QFlash(spi=SPI(2), cs=Pin(5), baud=2000000, software_reset=True)
 
 flash_mount_point = '/external'
@@ -207,10 +211,5 @@ his [post to use Winbond flash chips][ref-upy-forum-winbond-driver]
 [ref-rtd-micropython-winbond]: https://micropython-winbond.readthedocs.io/en/latest/
 [ref-remote-upy-shell]: https://github.com/dhylands/rshell
 [ref-brainelectronics-test-pypiserver]: https://github.com/brainelectronics/test-pypiserver
-[ref-be32]: https://github.com/brainelectronics/BE32-01/
-[ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py
-[ref-test-pypi]: https://test.pypi.org/
-[ref-pypi]: https://pypi.org/
-[ref-invalid-auth-test-pypi]: https://test.pypi.org/help/#invalid-auth
 [ref-crizeo]: https://forum.micropython.org/memberlist.php?mode=viewprofile&u=3067
 [ref-upy-forum-winbond-driver]: https://forum.micropython.org/viewtopic.php?f=16&t=3899&start=10

--- a/boot.py
+++ b/boot.py
@@ -33,8 +33,12 @@ try:
         # mosi  13            23
         # miso  12            19
         # cs    x, here 5     x, here 5
-        CS_PIN = Pin(5)
-        spi = SPI(2)
+        if 'esp32s3' in os_info.machine.lower():
+            CS_PIN = Pin(10)
+            spi = SPI(2, 2000000, sck=Pin(12), mosi=Pin(11), miso=Pin(13))
+        else:
+            CS_PIN = Pin(5)
+            spi = SPI(2)
     elif 'rp2' in os_info:
         # https://docs.micropython.org/en/latest/rp2/quickref.html#hardware-spi-bus
         # Pin   id=0   id=1
@@ -56,6 +60,12 @@ except Exception as e:
     raise e
 
 flash = W25QFlash(spi=spi, cs=CS_PIN, baud=2000000, software_reset=True)
+
+# get Flash infos/properties
+print("Flash manufacturer ID: 0x{0:02x}".format(flash.manufacturer))
+print("Flash Memory Type: {}".format(flash.mem_type))
+print("Flash Device Type: 0x{0:02x}".format(flash.device))
+print("Flash size: {} bytes".format(flash.capacity))
 
 flash_mount_point = '/external'
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 -->
+## [0.5.0] - 2023-05-14
+### Added
+- Properties for `manufacturer`, `mem_type`, `device`, `capacity`
+- BE-ESP32-01 specific pin and SPI definition in `boot.py`
+- Validate `package.json` file with every test workflow run but without version validation
+
+### Removed
+- Verbose print statements
+
 ## [0.4.0] - 2023-03-24
 ### Added
 - `package.json` for `mip` installation with MicroPython v1.19.1 or newer
@@ -72,8 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without hardware reset pins, extended documentation and PEP8 fixes
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-winbond/compare/0.4.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-winbond/compare/0.5.0...main
 
+[0.5.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.5.0
 [0.4.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.2.0

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -23,8 +23,17 @@ from winbond import W25QFlash
 # check the docs of your device for further details and pin infos
 CS_PIN = Pin(5)
 spi = SPI(0)
+# for the BE-ESP32-01 use
+# CS_PIN = Pin(10)
+# spi = SPI(2, 2000000, sck=Pin(12), mosi=Pin(11), miso=Pin(13))
 
 flash = W25QFlash(spi=spi, cs=CS_PIN, baud=2000000, software_reset=True)
+
+# get Flash infos/properties
+print("Flash manufacturer ID: 0x{0:02x}".format(flash.manufacturer))
+print("Flash Memory Type: {}".format(flash.mem_type))
+print("Flash Device Type: 0x{0:02x}".format(flash.device))
+print("Flash size: {} bytes".format(flash.capacity))
 # manufacturer: 0xef
 # mem_type: 64
 # device: 0x4016

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ flake8>=5.0.0,<6
 coverage>=6.4.2,<7
 nose2>=0.12.0,<1
 yamllint>=1.29,<2
+setup2upypackage>=0.2.0,<1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: Implementation :: MicroPython',
     ],
     keywords='micropython, winbond, library',
     project_urls={

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -93,7 +93,7 @@ class W25QFlash(object):
         """
         Get the manufacturer ID of the flash
 
-        :returns:   Memory type of the flash
+        :returns:   Manufacturer ID of the flash
         :rtype:     int
         """
         return self._manufacturer


### PR DESCRIPTION
### Added
- Properties for `manufacturer`, `mem_type`, `device`, `capacity`
- BE-ESP32-01 specific pin and SPI definition in `boot.py`
- Validate `package.json` file with every test workflow run but without version validation

### Removed
- Verbose print statements
