### PR TITLE
Fix flash properties return type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 -->
+## [0.5.1] - 2023-05-16
+### Fixed
+- Return type of `manufacturer` and `device` property fixed to be integers instead of strings, see #6
+- Better example string for the create file example in `main.py`
+
 ## [0.5.0] - 2023-05-14
 ### Added
 - Properties for `manufacturer`, `mem_type`, `device`, `capacity`
@@ -81,8 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without hardware reset pins, extended documentation and PEP8 fixes
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-winbond/compare/0.5.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-winbond/compare/0.5.1...main
 
+[0.5.1]: https://github.com/brainelectronics/micropython-winbond/tree/0.5.1
 [0.5.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.5.0
 [0.4.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/micropython-winbond/tree/0.3.0

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-import time
+from time import time
 import os   # os already imported by boot.py. This import is to satisfy flake8
 
 print('Entered main.py')
@@ -24,21 +24,20 @@ if external_test_file_name in os.listdir(flash_mount_point):
 
     # read back the file from the external flash
     with open(external_test_file_path, 'r') as file:
-        lines = file.readlines()
-        for line in lines:
+        for line in file.readlines():
             print(line)
 
     print('Appending new content to "{}"'.format(external_test_file_path))
     # append new content to file on the external flash
     with open(external_test_file_path, 'a') as file:
-        file.write('Hello World at {}\n'.format(time.time()))
+        file.write('Hello World at {}sec\n'.format(time()))
 else:
     print('No test file "{}" exists on external flash "{}", creating it now'.
           format(external_test_file_name, flash_mount_point))
 
     # append content to file on the external flash, create file is not exists
     with open(external_test_file_path, 'a+') as file:
-        file.write('Hello World at {}\n'.format(time.time()))
+        file.write('Hello World at {}sec\n'.format(time()))
 
 print('Listing all files and folders on the external flash directory "{}":'.
       format(flash_mount_point))

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -58,7 +58,7 @@ class W25QFlash(object):
         self.identify()
 
         # address length (default: 3 bytes, 32MB+: 4)
-        self._ADR_LEN = 3 if (len(bin(self._CAPACITY - 1)) - 2) <= 24 else 4
+        self._ADR_LEN = 3 if (len(bin(self._capacity - 1)) - 2) <= 24 else 4
 
         # setup address mode:
         if self._ADR_LEN == 4:
@@ -165,7 +165,7 @@ class W25QFlash(object):
         mf, mem_type, cap = self.spi.read(3, 0x00)
         self.cs(1)
 
-        self._CAPACITY = int(2**cap)
+        self._capacity = int(2**cap)
 
         if not (mf and mem_type and cap):  # something is 0x00
             raise OSError("device not responding, check wiring. ({}, {}, {})".
@@ -175,12 +175,9 @@ class W25QFlash(object):
             raise OSError("manufacturer ({}) or memory type ({}) unsupported".
                           format(hex(mf), hex(mem_type)))
 
-        self._manufacturer = hex(mf)
+        self._manufacturer = mf
         self._mem_type = mem_type
-        self._device_type = hex(mem_type << 8 | cap)
-        self._capacity = self._CAPACITY
-
-        # return self._CAPACITY  # calculate number of bytes
+        self._device_type = mem_type << 8 | cap
 
     def get_size(self) -> int:
         """
@@ -189,7 +186,7 @@ class W25QFlash(object):
         :returns:   The flash size in byte.
         :rtype:     int
         """
-        return self._CAPACITY
+        return self._capacity
 
     def format(self) -> None:
         """
@@ -265,9 +262,9 @@ class W25QFlash(object):
         :param      addr:  The start address
         :type       addr:  int
         """
-        assert addr + len(buf) <= self._CAPACITY, \
+        assert addr + len(buf) <= self._capacity, \
             "memory not addressable at %s with range %d (max.: %s)" % \
-            (hex(addr), len(buf), hex(self._CAPACITY - 1))
+            (hex(addr), len(buf), hex(self._capacity - 1))
 
         self._await()
         self.cs(0)
@@ -308,9 +305,9 @@ class W25QFlash(object):
             "invalid buffer length: {}".format(len(buf))
         assert not addr & 0xf, \
             "address ({}) not at page start".format(addr)
-        assert addr + len(buf) <= self._CAPACITY, \
+        assert addr + len(buf) <= self._capacity, \
             ("memory not addressable at {} with range {} (max.: {})".
-                format(hex(addr), len(buf), hex(self._CAPACITY - 1)))
+                format(hex(addr), len(buf), hex(self._capacity - 1)))
 
         for i in range(0, len(buf), self.PAGE_SIZE):
             self._wren()
@@ -405,4 +402,4 @@ class W25QFlash(object):
         :returns:   Number of blocks
         :rtype:     int
         """
-        return int(self._CAPACITY / self.BLOCK_SIZE)
+        return int(self._capacity / self.BLOCK_SIZE)


### PR DESCRIPTION
### Fixed
- Return type of `manufacturer` and `device` property fixed to be integers instead of strings, see #6
- Better example string for the create file example in `main.py`
