### PR TITLE
minor patches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Install the pre-commit hooks below with
+# 'pre-commit install'
+
+# Run the hooks on all files with
+# 'pre-commit run --all'
+
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear, flake8-print]
+        args: [--ignore=T201]

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 -->
+## [0.5.2] - 2023-11-15
+### Fixed
+- await function no longer caught in loop and has timeout of 2 seconds 
+- writeblocks no longer fails for invalid block lengths
+- packages no longer raises exception but prints warning if memory is untested
 ## [0.5.1] - 2023-05-16
 ### Fixed
 - Return type of `manufacturer` and `device` property fixed to be integers instead of strings, see #6

--- a/winbond/version.py
+++ b/winbond/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-__version_info__ = ("0", "0", "0")
+__version_info__ = ("0", "5", "2")
 __version__ = '.'.join(__version_info__)

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -398,6 +398,8 @@ class W25QFlash(object):
                                  buf=buf_mv[offset:offset + self.BLOCK_SIZE])
                 offset += self.BLOCK_SIZE
                 blocknum += 1
+        # remove appended bytes
+        buf = buf[:buf_len]
 
     def count(self) -> int:
         """

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -384,10 +384,10 @@ class W25QFlash(object):
         :type       buf:       list
         """
         buf_len = len(buf)
-        if buf_len % self.BLOCK_SIZE  != 0:
+        if buf_len % self.BLOCK_SIZE != 0:
             # appends xFF dummy bytes
-            buf += bytearray((self.BLOCK_SIZE - buf_len)*[255])
-        
+            buf += bytearray((self.BLOCK_SIZE - buf_len) * [255])
+
         if buf_len == self.BLOCK_SIZE:
             self._writeblock(blocknum=blocknum, buf=buf)
         else:


### PR DESCRIPTION
as outlined in https://github.com/brainelectronics/micropython-winbond/issues/8

Thanks for this great library! Helped me a lot.
I think the following could be done to make it even better.
I already added my suggested improvements.



**change await function**
```python
# last bit (1) is BUSY bit in stat. reg. byte (0 = not busy, 1 = busy)
trials = 0
while 0x1 & self.spi.read(1, 0xFF)[0]:
    trials += 1
    if trials > 20:
         raise Exception("Can't read from device")
    sleep(0.1)
```
Current code can lead to infinite loop and you should do somethingl like above

**writeblocks should not check block length**
You check block length and raise warning if not satisfied.
This is against spec (https://docs.micropython.org/en/latest/library/os.html).
Also gives issue if you write a file raw to memory with a size not equal to multiple of blocks
```python
if len(buf) %buffsize != 0:
    buf += bytearray((buffsize-(len(buf)*[255]))
# NOTE: in my final fix I remove the appended bytes
```
**don't break just raise warning**
I would do something like this in the identify function.
```python
if mf != 0xEF or mem_type not in [0x40, 0x60, 0x70]:
    # Winbond manufacturer, Q25 series memory (tested 0x40 only)
    print(f"manufacturer ({}) or memory type ({}) note tested")
```


