### PR TITLE
fixed string formatting for micropython

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 -->
+## [0.5.3] - 2024-05-30
+### Fixed
+- fixed string formatting for compatibility with micropython
 ## [0.5.2] - 2023-11-15
 ### Fixed
 - await function no longer caught in loop and has timeout of 2 seconds 

--- a/winbond/version.py
+++ b/winbond/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-__version_info__ = ("0", "5", "2")
-__version__ = '.'.join(__version_info__)
+__version_info__ = ("0", "5", "3")
+__version__ = ".".join(__version_info__)

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -172,8 +172,8 @@ class W25QFlash(object):
                           format(hex(mf), hex(mem_type), hex(cap)))
         if mf != 0xEF or mem_type not in [0x40, 0x60, 0x70]:
             # Winbond manufacturer, Q25 series memory (tested 0x40 only)
-            print(f"Warning manufacturer ({hex(mf)}) or memory type"
-                  f"({hex(mem_type)}) not tested.")
+            print(f"""Warning manufacturer ({hex(mf)}) or memory type
+                      ({hex(mem_type)}) not tested.""")
 
         self._manufacturer = mf
         self._mem_type = mem_type


### PR DESCRIPTION
Current code fails on line 176 was also seen by https://github.com/brainelectronics/micropython-winbond/issues/11
I introduced this in my last commit, my apologies.
The following is valid in python but not in micropython.

```python
print(f"Warning manufacturer ({hex(mf)}) or memory type"
        f"({hex(mem_type)}) not tested.")
```
I replaced it with
```python
print(f"""Warning manufacturer ({hex(mf)}) or memory type"
             ({hex(mem_type)}) not tested.""")
```
It has been tested in micropython. Ideally, there would be some checks to test valid micropython.

