### PR TITLE
fix Extremely slow interaction issue #11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 -->
+## [0.5.4] - 2024-05-30
+### Fixed
+- sleep changed to microsecond sleep to speed up flashing
 ## [0.5.3] - 2024-05-30
 ### Fixed
 - fixed string formatting for compatibility with micropython

--- a/winbond/version.py
+++ b/winbond/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-__version_info__ = ("0", "5", "3")
+__version_info__ = ("0", "5", "4")
 __version__ = ".".join(__version_info__)

--- a/winbond/winbond.py
+++ b/winbond/winbond.py
@@ -233,9 +233,9 @@ class W25QFlash(object):
         # last bit (1) is BUSY bit in stat. reg. byte (0 = not busy, 1 = busy)
         trials = 0
         while 0x1 & self.spi.read(1, 0xFF)[0]:
-            if trials > 20:
+            if trials > 5E6:
                 raise Exception("Device keeps busy, aborting.")
-            time.sleep(0.1)
+            time.sleep_us(1)
             trials += 1
         self.cs(1)
         self._busy = False


### PR DESCRIPTION
as pointed out by @EQStack The extremely slow writing diappears when sleep(0.1) in _await is replaced e.g. by sleep_us(1) and much higher trials count (or there is no busy time limit).  https://github.com/brainelectronics/micropython-winbond/issues/11
This should at least fix the slow writing.

I also introduced this issue with my commit last year :-).